### PR TITLE
sloc starts with Atom by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "version": "1.1.0",
   "description": "Counts the number of lines of code in the file.",
   "keywords": [],
-  "activationCommands": {
-    "atom-workspace": "sloc:toggle"
-  },
   "repository": "https://github.com/sgade/sloc",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Currently, `sloc` is toggled off when starting Atom. For some reason it needs to toggled twice before the line count appears in the status bar. Removing `acivationCommands` from `package.json` eliminates the need of this initial toggle and shows the line count by default. 

Perhaps a better solution would be to let each user set their own preferential settings for this package, but I believe having it on by default is already an improvement.