### PR TITLE
Improvements to Sloc unavailable message

### DIFF
--- a/lib/sloc-view.coffee
+++ b/lib/sloc-view.coffee
@@ -28,5 +28,5 @@ class SlocView
     if status
       text = "Lines: " + status?.total + "\tSource: " + status?.source + "\tComments: " + status?.comment + "\tEmpty: " + status?.empty
     else
-      text = "Sloc unavailable"
+      text = atom.config.get('sloc.unavailableMessage')
     @message.textContent = text

--- a/lib/sloc.coffee
+++ b/lib/sloc.coffee
@@ -51,6 +51,7 @@ module.exports = Sloc =
   update: ->
     editor = atom.workspace.getActiveTextEditor()
     if not editor
+      @slocView.setSlocInfo null
       return
 
     content = editor.getBuffer().getLines().join('\n')

--- a/lib/sloc.coffee
+++ b/lib/sloc.coffee
@@ -5,7 +5,6 @@ sloc = require 'sloc'
 module.exports = Sloc =
   slocView: null
   subscriptions: null
-
   statusBar: null
 
   activate: (state) ->

--- a/package.json
+++ b/package.json
@@ -18,5 +18,13 @@
         "^1.0.0": "consumeStatusBar"
       }
     }
+  },
+  "configSchema": {
+    "unavailableMessage": {
+      "title": "Sloc unavailable message",
+      "description": "This is the message which will be displayed when Sloc does not support a language",
+      "type": "string",
+      "default": ""
+    }
   }
 }


### PR DESCRIPTION
Improvements to Sloc unavailable message:

* when the very last buffer is closed, the last line count was continued to be displayed. This has been fixed.
* sloc now has a setting option where the user can set their own default message to be displayed when sloc isn't available for a specific language. Default message is blank.